### PR TITLE
ENH: Added automatic deployment of docker containers through github actions

### DIFF
--- a/.github/workflows/build_ukf.yml
+++ b/.github/workflows/build_ukf.yml
@@ -1,0 +1,45 @@
+name: Deploy UKFTractography Container
+
+on:
+  push:
+    branches: [ main ]
+    # Publish semver tags as releases.
+    tags: [ 'v*.*.*' ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+  
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      # Check out code
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      # And make it available for the builds
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: containers/ukftractography
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/ukf:latest
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/build_ukf.yml
+++ b/.github/workflows/build_ukf.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           context: containers/ukftractography
           push: true
-          tags: tigrlab/ukf:latest
+          tags: tigrlab/ukftractography:latest
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
       - name: Move cache

--- a/.github/workflows/build_ukf.yml
+++ b/.github/workflows/build_ukf.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           context: containers/ukftractography
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/ukf:latest
+          tags: tigrlab/ukf:latest
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
       - name: Move cache

--- a/.github/workflows/build_ukf.yml
+++ b/.github/workflows/build_ukf.yml
@@ -3,10 +3,12 @@ name: Deploy UKFTractography Container
 on:
   push:
     branches: [ main ]
+    paths: 'containers/ukftractography/*'
     # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
   pull_request:
     branches: [ main ]
+    paths: 'containers/ukftractography/*'
   workflow_dispatch:
   
 jobs:
@@ -28,8 +30,8 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       # And make it available for the builds
       - name: Build and push
         uses: docker/build-push-action@v2

--- a/.github/workflows/build_wma.yml
+++ b/.github/workflows/build_wma.yml
@@ -1,0 +1,45 @@
+name: Deploy whitematteranalysis Container
+
+on:
+  push:
+    branches: [ main ]
+    # Publish semver tags as releases.
+    tags: [ 'v*.*.*' ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+  
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      # Check out code
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      # And make it available for the builds
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: containers/whitematteranalysis
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/wma:latest
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/build_wma.yml
+++ b/.github/workflows/build_wma.yml
@@ -28,8 +28,8 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       # And make it available for the builds
       - name: Build and push
         uses: docker/build-push-action@v2

--- a/.github/workflows/build_wma.yml
+++ b/.github/workflows/build_wma.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           context: containers/whitematteranalysis
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/wma:latest
+          tags: tigrlab/wma:latest
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
       - name: Move cache

--- a/.github/workflows/build_wma.yml
+++ b/.github/workflows/build_wma.yml
@@ -3,10 +3,12 @@ name: Deploy whitematteranalysis Container
 on:
   push:
     branches: [ main ]
+    paths: 'containers/whitematteranalysis/*'
     # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
   pull_request:
     branches: [ main ]
+    paths: 'containers/whitematteranalysis/*'
   workflow_dispatch:
   
 jobs:
@@ -36,7 +38,7 @@ jobs:
         with:
           context: containers/whitematteranalysis
           push: true
-          tags: tigrlab/wma:latest
+          tags: tigrlab/whitematteranalysis:latest
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
       - name: Move cache


### PR DESCRIPTION
Here's the github action files to automatically build and push our containers to docker on commits. 

Note that this will automatically push public docker containers to <username>/ukf:latest and <username>/wma:latest. We can turn off the actual push by turning push to false [here](https://github.com/TIGRLab/dmri_analyses/blob/de033e18b3b2b2b8a956a4726765a89430f533db/.github/workflows/build_ukf.yml#L38+).

This method will also cache, for example the ukf build was 32 mins on the [first run](https://github.com/slimnsour/dmri_analyses/actions/runs/1118525660) and then 2 mins on the [next](https://github.com/slimnsour/dmri_analyses/actions/runs/1120429356).

Addresses https://github.com/TIGRLab/dmri_analyses/issues/1