### PR TITLE
ENH: Added options to release on a specific docker version manually

### DIFF
--- a/.github/workflows/build_ukf.yml
+++ b/.github/workflows/build_ukf.yml
@@ -1,15 +1,22 @@
 name: Deploy UKFTractography Container
 
 on:
+  # Automatic pushes will release as unstable
   push:
     branches: [ main ]
     paths: 'containers/ukftractography/*'
-    # Publish semver tags as releases.
-    tags: [ 'v*.*.*' ]
   pull_request:
     branches: [ main ]
     paths: 'containers/ukftractography/*'
+  # Manual push will release as latest
   workflow_dispatch:
+    branches: [ main ]
+    paths: 'containers/ukftractography/*'
+    inputs:
+      version:
+        description: 'Docker Push Version'     
+        required: false
+        default: 'unstable'
   
 jobs:
   docker:
@@ -34,11 +41,21 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
       # And make it available for the builds
       - name: Build and push
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
         uses: docker/build-push-action@v2
         with:
           context: containers/ukftractography
           push: true
-          tags: tigrlab/ukftractography:latest
+          tags: tigrlab/ukftractography:unstable
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+      - name: Build and push manual
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        uses: docker/build-push-action@v2
+        with:
+          context: containers/ukftractography
+          push: true
+          tags: tigrlab/ukftractography:${{ github.event.inputs.version }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
       - name: Move cache

--- a/.github/workflows/build_wma.yml
+++ b/.github/workflows/build_wma.yml
@@ -1,15 +1,22 @@
 name: Deploy whitematteranalysis Container
 
 on:
+  # Automatic pushes will release as unstable
   push:
     branches: [ main ]
     paths: 'containers/whitematteranalysis/*'
-    # Publish semver tags as releases.
-    tags: [ 'v*.*.*' ]
   pull_request:
     branches: [ main ]
     paths: 'containers/whitematteranalysis/*'
+  # Manual push will release as latest
   workflow_dispatch:
+    branches: [ main ]
+    paths: 'containers/whitematteranalysis/*'
+    inputs:
+      version:
+        description: 'Docker Push Version'     
+        required: false
+        default: 'unstable'
   
 jobs:
   docker:
@@ -34,11 +41,21 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
       # And make it available for the builds
       - name: Build and push
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
         uses: docker/build-push-action@v2
         with:
           context: containers/whitematteranalysis
           push: true
-          tags: tigrlab/whitematteranalysis:latest
+          tags: tigrlab/whitematteranalysis:unstable
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+      - name: Build and push manual
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        uses: docker/build-push-action@v2
+        with:
+          context: containers/whitematteranalysis
+          push: true
+          tags: tigrlab/whitematteranalysis:${{ github.event.inputs.version }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
       - name: Move cache

--- a/containers/ukftractography/Dockerfile
+++ b/containers/ukftractography/Dockerfile
@@ -76,5 +76,7 @@ ENV PATH="/src/ukf/build/UKFTractography-build/UKFTractography/bin:$PATH"
 # Copy command line script
 COPY run_ukf.sh /src/
 
+RUN chmod +x /src/run_ukf.sh
+
 WORKDIR $HOME
 ENTRYPOINT ["/src/run_ukf.sh"]

--- a/containers/whitematteranalysis/Dockerfile
+++ b/containers/whitematteranalysis/Dockerfile
@@ -97,5 +97,7 @@ ENV LD_LIBRARY_PATH="${SLICER_LIB}/Slicer-4.10:${SLICER_CLI}:${SLICER_LIB}/Pytho
 # Copy command line script
 COPY run_wma.sh /src/
 
+RUN chmod +x /src/run_wma.sh
+
 WORKDIR $HOME
 ENTRYPOINT ["/src/run_wma.sh"]


### PR DESCRIPTION
Added the option to release a specific version manually when you run a workflow (default value unstable). You can do this on the repo by going to Github Actions -> Deploy Container -> Run workflow (besides the "This workflow has a workflow_dispatch event trigger." notice). From this we can release specific versions or push to "latest" manually.

Also changed the automatic builds to go to the unstable version.